### PR TITLE
Introducing noise to Velodyne LiDAR HDL-32

### DIFF
--- a/vehicle_description/velodyne_hdl32/model.sdf
+++ b/vehicle_description/velodyne_hdl32/model.sdf
@@ -100,6 +100,12 @@
                 <update_rate>30</update_rate>
 
                 <ray>
+                    <noise>
+                        <!-- Use gaussian noise -->
+                        <type>gaussian</type>
+                        <mean>0.0</mean>
+                        <stddev>0.02</stddev>
+                    </noise>
                     <!-- The scan element contains the horizontal and vertical beams.
                     We are leaving out the vertical beams for this tutorial. -->
                     <scan>


### PR DESCRIPTION
Hi all,

in this PR we just add noise to the Velodyne LiDAR HDL-32 sensor.

Although the change is really small, it's something important, so, that is why was created a Pull Request specifically for that.

Import to know that the changes made here are well explained on the Gazebo Tutorial named 
[Sensor Noise Model](http://gazebosim.org/tutorials?tut=sensor_noise&cat=sensors).