### PR TITLE
Velodyne LiDAR plugin that reads from a topic.

### DIFF
--- a/plugins/velodyne_plugin/CMakeLists.txt
+++ b/plugins/velodyne_plugin/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
+
+# Find Gazebo
+find_package(gazebo REQUIRED)
+include_directories(${GAZEBO_INCLUDE_DIRS})
+link_directories(${GAZEBO_LIBRARY_DIRS})
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${GAZEBO_CXX_FLAGS}")
+
+# Build our plugin
+add_library(velodyne_plugin SHARED velodyne_plugin.cc)
+target_link_libraries(velodyne_plugin ${GAZEBO_libraries})

--- a/plugins/velodyne_plugin/CMakeLists.txt
+++ b/plugins/velodyne_plugin/CMakeLists.txt
@@ -9,3 +9,16 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${GAZEBO_CXX_FLAGS}")
 # Build our plugin
 add_library(velodyne_plugin SHARED velodyne_plugin.cc)
 target_link_libraries(velodyne_plugin ${GAZEBO_libraries})
+
+
+# Build the stand-alone test program
+add_executable(velodyne_api_client velodyne_api_client.cc)
+
+if (${gazebo_VERSION_MAJOR} LESS 6)
+  # These two
+  include(FindBoost)
+  find_package(Boost ${MIN_BOOST_VERSION} REQUIRED system filesystem regex)
+  target_link_libraries(velodyne_api_client ${GAZEBO_LIBRARIES} ${Boost_LIBRARIES})
+else()
+  target_link_libraries(velodyne_api_client ${GAZEBO_LIBRARIES})
+endif()

--- a/plugins/velodyne_plugin/velodyne.world
+++ b/plugins/velodyne_plugin/velodyne.world
@@ -1,0 +1,24 @@
+<?xml version="1.0" ?>
+<sdf version="1.5">
+    <world name="default">
+        <!-- A global light source -->
+        <include>
+            <uri>model://sun</uri>
+        </include>
+        <!-- A ground plane -->
+        <include>
+            <uri>model://ground_plane</uri>
+        </include>
+
+        <!-- A testing model that includes the Velodyne sensor model -->
+        <model name="my_velodyne">
+            <include>
+                <uri>model://velodyne_hdl32</uri>
+            </include>
+
+            <!-- Attach the plugin to this model -->
+            <plugin name="velodyne_control" filename="libvelodyne_plugin.so"/>
+        </model>
+
+    </world>
+</sdf>

--- a/plugins/velodyne_plugin/velodyne.world
+++ b/plugins/velodyne_plugin/velodyne.world
@@ -17,7 +17,9 @@
             </include>
 
             <!-- Attach the plugin to this model -->
-            <plugin name="velodyne_control" filename="libvelodyne_plugin.so"/>
+            <plugin name="velodyne_control" filename="libvelodyne_plugin.so">
+                 <velocity>25</velocity>
+            </plugin>
         </model>
 
     </world>

--- a/plugins/velodyne_plugin/velodyne_api_client.cc
+++ b/plugins/velodyne_plugin/velodyne_api_client.cc
@@ -1,0 +1,53 @@
+#include <gazebo/gazebo_config.h>
+#include <gazebo/transport/transport.hh>
+#include <gazebo/msgs/msgs.hh>
+
+// Gazebo's API has changed between major releases. These changes are
+// accounted for with #if..#endif blocks in this file.
+#if GAZEBO_MAJOR_VERSION < 6
+#include <gazebo/gazebo.hh>
+#else
+#include <gazebo/gazebo_client.hh>
+#endif
+
+/////////////////////////////////////////////////
+
+int main(int _argc, char **_argv) {
+    // Load gazebo as a client
+#if GAZEBO_MAJOR_VERSION < 6
+    gazebo::setupClient(_argc, _argv);
+#else
+    gazebo::client::setup(_argc, _argv);
+#endif
+
+    // Create our node for communication
+    gazebo::transport::NodePtr node(new gazebo::transport::Node());
+    node->Init();
+
+    // Publish to the  velodyne topic
+    gazebo::transport::PublisherPtr pub =
+            node->Advertise<gazebo::msgs::Vector3d>("~/my_velodyne/vel_cmd");
+
+    // Wait for a subscriber to connect to this publisher
+    pub->WaitForConnection();
+
+    // Create a a vector3 message
+    gazebo::msgs::Vector3d msg;
+
+    // Set the velocity in the x-component
+#if GAZEBO_MAJOR_VERSION < 6
+    gazebo::msgs::Set(&msg, gazebo::math::Vector3(std::atof(_argv[1]), 0, 0));
+#else
+    gazebo::msgs::Set(&msg, ignition::math::Vector3d(std::atof(_argv[1]), 0, 0));
+#endif
+
+    // Send the message
+    pub->Publish(msg);
+
+    // Make sure to shut everything down.
+#if GAZEBO_MAJOR_VERSION < 6
+    gazebo::shutdown();
+#else
+    gazebo::client::shutdown();
+#endif
+}

--- a/plugins/velodyne_plugin/velodyne_plugin.cc
+++ b/plugins/velodyne_plugin/velodyne_plugin.cc
@@ -88,6 +88,14 @@ namespace gazebo {
               this->joint->GetScopedName(), _vel);
         }
 
+        /// \brief Handle incoming message
+        /// \param[in] _msg Repurpose a vector3 message. This function will
+        /// only use the x component.
+        private: void OnMsg(ConstVector3dPtr &_msg)
+        {
+          this->SetVelocity(_msg->x());
+        }
+
         /// \brief Pointer to the model.
         private: physics::ModelPtr model;
 

--- a/plugins/velodyne_plugin/velodyne_plugin.cc
+++ b/plugins/velodyne_plugin/velodyne_plugin.cc
@@ -76,6 +76,17 @@ namespace gazebo {
 
         /// \brief A PID controller for the joint.
         private: common::PID pid;
+
+
+        ///////////////////////////////////////////////////////////////////////
+        // Messaging passing infrastructure
+        ///////////////////////////////////////////////////////////////////////
+
+        /// \brief A node used for transport
+        private: transport::NodePtr node;
+
+        /// \brief A subscriber to a named topic.
+        private: transport::SubscriberPtr sub;
     };
 
     // Tell Gazebo about this plugin, so that Gazebo can call Load on this plugin.

--- a/plugins/velodyne_plugin/velodyne_plugin.cc
+++ b/plugins/velodyne_plugin/velodyne_plugin.cc
@@ -1,0 +1,34 @@
+#ifndef _VELODYNE_PLUGIN_HH_
+#define _VELODYNE_PLUGIN_HH_
+
+#include <gazebo/gazebo.hh>
+#include <gazebo/physics/physics.hh>
+
+namespace gazebo {
+    /// \brief A plugin to control a Velodyne sensor.
+
+    class VelodynePlugin : public ModelPlugin {
+        /// \brief Constructor
+    public:
+
+        VelodynePlugin() {
+        }
+
+        /// \brief The load function is called by Gazebo when the plugin is
+        /// inserted into simulation
+        /// \param[in] _model A pointer to the model that this plugin is
+        /// attached to.
+        /// \param[in] _sdf A pointer to the plugin's SDF element.
+    public:
+
+        virtual void Load(physics::ModelPtr _model, sdf::ElementPtr _sdf) {
+            // Just output a message for now
+            std::cerr << "\nThe velodyne plugin is attach to model[" <<
+                    _model->GetName() << "]\n";
+        }
+    };
+
+    // Tell Gazebo about this plugin, so that Gazebo can call Load on this plugin.
+    GZ_REGISTER_MODEL_PLUGIN(VelodynePlugin)
+}
+#endif

--- a/plugins/velodyne_plugin/velodyne_plugin.cc
+++ b/plugins/velodyne_plugin/velodyne_plugin.cc
@@ -32,6 +32,13 @@ namespace gazebo {
             std::cerr << "\nThe velodyne plugin is attach to model[" <<
                     _model->GetName() << "]\n";
 
+            // Default to zero velocity
+            double velocity = 0;
+
+            // Check that the velocity element exists, then read the value
+            if (_sdf->HasElement("velocity"))
+              velocity = _sdf->Get<double>("velocity");
+
             // Store the model pointer for convenience.
             this->model = _model;
 
@@ -49,7 +56,7 @@ namespace gazebo {
             // Set the joint's target velocity. This target velocity is just
             // for demonstration purposes.
             this->model->GetJointController()->SetVelocityTarget(
-                    this->joint->GetScopedName(), 10.0);
+                    this->joint->GetScopedName(), velocity);
         }
 
         /// \brief Pointer to the model.

--- a/plugins/velodyne_plugin/velodyne_plugin.cc
+++ b/plugins/velodyne_plugin/velodyne_plugin.cc
@@ -3,6 +3,8 @@
 
 #include <gazebo/gazebo.hh>
 #include <gazebo/physics/physics.hh>
+#include <gazebo/transport/transport.hh>
+#include <gazebo/msgs/msgs.hh>
 
 namespace gazebo {
     /// \brief A plugin to control a Velodyne sensor.

--- a/plugins/velodyne_plugin/velodyne_plugin.cc
+++ b/plugins/velodyne_plugin/velodyne_plugin.cc
@@ -59,6 +59,15 @@ namespace gazebo {
                     this->joint->GetScopedName(), velocity);
         }
 
+        /// \brief Set the velocity of the Velodyne
+        /// \param[in] _vel New target velocity
+        public: void SetVelocity(const double &_vel)
+        {
+          // Set the joint's target velocity.
+          this->model->GetJointController()->SetVelocityTarget(
+              this->joint->GetScopedName(), _vel);
+        }
+
         /// \brief Pointer to the model.
         private: physics::ModelPtr model;
 

--- a/plugins/velodyne_plugin/velodyne_plugin.cc
+++ b/plugins/velodyne_plugin/velodyne_plugin.cc
@@ -57,6 +57,26 @@ namespace gazebo {
             // for demonstration purposes.
             this->model->GetJointController()->SetVelocityTarget(
                     this->joint->GetScopedName(), velocity);
+
+            ///////////////////////////////////////////////////////////////////
+            // Instantiate the subscriber to be able to read from a topic
+            ///////////////////////////////////////////////////////////////////
+
+            // Create the node
+            this->node = transport::NodePtr(new transport::Node());
+
+            #if GAZEBO_MAJOR_VERSION < 8
+                this->node->Init(this->model->GetWorld()->GetName());
+            #else
+                this->node->Init(this->model->GetWorld()->Name());
+            #endif
+
+            // Create a topic name
+            std::string topicName = "~/" + this->model->GetName() + "/vel_cmd";
+
+            // Subscribe to the topic, and register a callback
+            this->sub = this->node->Subscribe(topicName,
+                    &VelodynePlugin::OnMsg, this);
         }
 
         /// \brief Set the velocity of the Velodyne

--- a/plugins/velodyne_plugin/velodyne_plugin.cc
+++ b/plugins/velodyne_plugin/velodyne_plugin.cc
@@ -22,10 +22,44 @@ namespace gazebo {
     public:
 
         virtual void Load(physics::ModelPtr _model, sdf::ElementPtr _sdf) {
+            // Safety check
+            if (_model->GetJointCount() == 0) {
+                std::cerr << "Invalid joint count, Velodyne plugin not loaded\n";
+                return;
+            }
+
             // Just output a message for now
             std::cerr << "\nThe velodyne plugin is attach to model[" <<
                     _model->GetName() << "]\n";
+
+            // Store the model pointer for convenience.
+            this->model = _model;
+
+            // Get the first joint. We are making an assumption about the model
+            // having one joint that is the rotational joint.
+            this->joint = _model->GetJoints()[0];
+
+            // Setup a P-controller, with a gain of 0.1.
+            this->pid = common::PID(0.1, 0, 0);
+
+            // Apply the P-controller to the joint.
+            this->model->GetJointController()->SetVelocityPID(
+                    this->joint->GetScopedName(), this->pid);
+
+            // Set the joint's target velocity. This target velocity is just
+            // for demonstration purposes.
+            this->model->GetJointController()->SetVelocityTarget(
+                    this->joint->GetScopedName(), 10.0);
         }
+
+        /// \brief Pointer to the model.
+        private: physics::ModelPtr model;
+
+        /// \brief Pointer to the joint.
+        private: physics::JointPtr joint;
+
+        /// \brief A PID controller for the joint.
+        private: common::PID pid;
     };
 
     // Tell Gazebo about this plugin, so that Gazebo can call Load on this plugin.


### PR DESCRIPTION
Hi all,

in this PR we add a plugin to rotate the `Velodyne LiDAR` sensor.

The plugin (`velodyne_plugin.cc` ) reads the new rotation velocity from a `Gazebo Topic`.

In order to publish on that topic, an `API Client` was added (`velodyne_api_client.cc`).

In order to test the features added on this PR, you will have to:

1. Compile the plugin

* `cd velodyne_plugin`
* `mkdir build`
* `cmake ..`
* `make`

2. Run the velodyne.world
* `cd velodyne_plugin/build`
* `gazebo --verbose ../velodyne.world`

3. Call the `velodyne_api_client` with the desired velocity.

* `cd velodyne_plugin/build`
* `./velodyne_api_client 20`

Important to know that what we have implemented here is basically what you can find on the Intermediate Gazebo Tutorial named [Control plugin](http://gazebosim.org/tutorials?cat=guided_i&tut=guided_i5).
