### PR TITLE
Connect Velodyne LiDAR plugin to ROS

### DIFF
--- a/plugins/velodyne_plugin/CMakeLists.txt
+++ b/plugins/velodyne_plugin/CMakeLists.txt
@@ -1,5 +1,11 @@
 cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
 
+# Find ROS
+find_package(roscpp REQUIRED)
+find_package(std_msgs REQUIRED)
+include_directories(${roscpp_INCLUDE_DIRS})
+include_directories(${std_msgs_INCLUDE_DIRS})
+
 # Find Gazebo
 find_package(gazebo REQUIRED)
 include_directories(${GAZEBO_INCLUDE_DIRS})
@@ -8,7 +14,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${GAZEBO_CXX_FLAGS}")
 
 # Build our plugin
 add_library(velodyne_plugin SHARED velodyne_plugin.cc)
-target_link_libraries(velodyne_plugin ${GAZEBO_libraries})
+target_link_libraries(velodyne_plugin ${GAZEBO_libraries} ${roscpp_LIBRARIES})
 
 
 # Build the stand-alone test program

--- a/plugins/velodyne_plugin/velodyne_plugin.cc
+++ b/plugins/velodyne_plugin/velodyne_plugin.cc
@@ -1,6 +1,14 @@
 #ifndef _VELODYNE_PLUGIN_HH_
 #define _VELODYNE_PLUGIN_HH_
 
+// ROS
+#include <thread>
+#include "ros/ros.h"
+#include "ros/callback_queue.h"
+#include "ros/subscribe_options.h"
+#include "std_msgs/Float32.h"
+
+// Gazebo
 #include <gazebo/gazebo.hh>
 #include <gazebo/physics/physics.hh>
 #include <gazebo/transport/transport.hh>
@@ -79,6 +87,36 @@ namespace gazebo {
             // Subscribe to the topic, and register a callback
             this->sub = this->node->Subscribe(topicName,
                     &VelodynePlugin::OnMsg, this);
+
+
+            //-----------------------------------------------------------------
+            // ROS Support
+            //-----------------------------------------------------------------
+            // Initialize ros, if it has not already bee initialized.
+            if (!ros::isInitialized())
+            {
+              int argc = 0;
+              char **argv = NULL;
+              ros::init(argc, argv, "gazebo_client",
+                  ros::init_options::NoSigintHandler);
+            }
+
+            // Create our ROS node. This acts in a similar manner to
+            // the Gazebo node
+            this->rosNode.reset(new ros::NodeHandle("gazebo_client"));
+
+            // Create a named topic, and subscribe to it.
+            ros::SubscribeOptions so =
+              ros::SubscribeOptions::create<std_msgs::Float32>(
+                  "/" + this->model->GetName() + "/vel_cmd",
+                  1,
+                  boost::bind(&VelodynePlugin::OnRosMsg, this, _1),
+                  ros::VoidPtr(), &this->rosQueue);
+            this->rosSub = this->rosNode->subscribe(so);
+
+            // Spin up the queue helper thread.
+            this->rosQueueThread =
+              std::thread(std::bind(&VelodynePlugin::QueueThread, this));
         }
 
         /// \brief Set the velocity of the Velodyne
@@ -97,6 +135,26 @@ namespace gazebo {
         {
           this->SetVelocity(_msg->x());
         }
+
+        //---------------------------------------------------------------------
+        // ROS Support
+        //---------------------------------------------------------------------
+
+        /// \brief A node use for ROS transport
+        private: std::unique_ptr<ros::NodeHandle> rosNode;
+
+        /// \brief A ROS subscriber
+        private: ros::Subscriber rosSub;
+
+        /// \brief A ROS callbackqueue that helps process messages
+        private: ros::CallbackQueue rosQueue;
+
+        /// \brief A thread the keeps running the rosQueue
+        private: std::thread rosQueueThread;
+
+        //---------------------------------------------------------------------
+        // Gazebo Support
+        //---------------------------------------------------------------------
 
         /// \brief Pointer to the model.
         private: physics::ModelPtr model;

--- a/plugins/velodyne_plugin/velodyne_plugin.cc
+++ b/plugins/velodyne_plugin/velodyne_plugin.cc
@@ -140,6 +140,24 @@ namespace gazebo {
         // ROS Support
         //---------------------------------------------------------------------
 
+        /// \brief Handle an incoming message from ROS
+        /// \param[in] _msg A float value that is used to set the velocity
+        /// of the Velodyne.
+        public: void OnRosMsg(const std_msgs::Float32ConstPtr &_msg)
+        {
+          this->SetVelocity(_msg->data);
+        }
+
+        /// \brief ROS helper function that processes messages
+        private: void QueueThread()
+        {
+          static const double timeout = 0.01;
+          while (this->rosNode->ok())
+          {
+            this->rosQueue.callAvailable(ros::WallDuration(timeout));
+          }
+        }
+
         /// \brief A node use for ROS transport
         private: std::unique_ptr<ros::NodeHandle> rosNode;
 


### PR DESCRIPTION
Hi all,

in this PR we modify our Velodyne LiDAR (Gazebo Plugin) to work with ROS.

The plugin subscribes to the ROS Topic called `~/vel_cmd` .

When a new message is received, the new velocity is set.

In order to compile and make it works, you have to do the following:

1. `source /path/to/catkin_ws/src/setup.bash`
2. `source /usr/share/gazebo/setup.sh`
3. `cd /path/to/plugins/velodyne_plugin/build`
4. `cmake ../`
5. `make`
6. `gazebo ../velodyne.world --verbose &`
7. `rostopic pub /my_velodyne/vel_cmd std_msgs/Float32 10.0 --once`

With the steps mentioned above, you should be able to change the velocity of the LiDAR using ROS Topics.

Important to note that all the changes made on this PR can be found on the Gazebo Intermediate Tutorial named [Intermediate: Connect to ROS](http://gazebosim.org/tutorials?cat=guided_i&tut=guided_i6).

